### PR TITLE
Add the missing parity options for Windows

### DIFF
--- a/asyn/asynRecord/asynRecord.dbd
+++ b/asyn/asynRecord/asynRecord.dbd
@@ -66,6 +66,8 @@ menu(serialPRTY) {
     choice(serialPRTY_None,"None")
     choice(serialPRTY_Even,"Even")
     choice(serialPRTY_Odd,"Odd")
+    choice(serialPRTY_Mark,"Mark")
+    choice(serialPRTY_Space,"Space")
 }
 menu(serialDBIT) {
     choice(serialDBIT_unknown,"Unknown")

--- a/asyn/drvAsynSerial/drvAsynSerialPort.c
+++ b/asyn/drvAsynSerial/drvAsynSerialPort.c
@@ -153,12 +153,16 @@ getOption(void *drvPvt, asynUser *pasynUser,
     }
     else if (epicsStrCaseCmp(key, "parity") == 0) {
         if (tty->termios.c_cflag & PARENB) {
+#ifdef CMSPAR
             if (tty->termios.c_cflag & CMSPAR) {
+#else
+            if (0) {
+#endif /* CMSPAR */
 				if (tty->termios.c_cflag & PARODD)
 					l = epicsSnprintf(val, valSize, "mark");
 				else
 					l = epicsSnprintf(val, valSize, "space");
-			else {
+			} else {
 				if (tty->termios.c_cflag & PARODD)
 					l = epicsSnprintf(val, valSize, "odd");
 				else
@@ -377,6 +381,9 @@ setOption(void *drvPvt, asynUser *pasynUser, const char *key, const char *val)
         }
     }
     else if (epicsStrCaseCmp(key, "parity") == 0) {
+#ifdef CMSPAR
+        tty->termios.c_cflag &= ~CMSPAR;
+#endif /* CMSPAR */
         if (epicsStrCaseCmp(val, "none") == 0) {
             tty->termios.c_cflag &= ~PARENB;
         }
@@ -388,6 +395,7 @@ setOption(void *drvPvt, asynUser *pasynUser, const char *key, const char *val)
             tty->termios.c_cflag |= PARENB;
             tty->termios.c_cflag |= PARODD;
         }
+#ifdef CMSPAR
         else if (epicsStrCaseCmp(val, "space") == 0) {
             tty->termios.c_cflag |= PARENB;
             tty->termios.c_cflag |= CMSPAR;
@@ -398,6 +406,7 @@ setOption(void *drvPvt, asynUser *pasynUser, const char *key, const char *val)
             tty->termios.c_cflag |= CMSPAR;
             tty->termios.c_cflag |= PARODD;
         }
+#endif /* CMSPAR */
         else {
             epicsSnprintf(pasynUser->errorMessage,pasynUser->errorMessageSize,
                                                             "Invalid parity.");

--- a/asyn/drvAsynSerial/drvAsynSerialPort.c
+++ b/asyn/drvAsynSerial/drvAsynSerialPort.c
@@ -153,10 +153,17 @@ getOption(void *drvPvt, asynUser *pasynUser,
     }
     else if (epicsStrCaseCmp(key, "parity") == 0) {
         if (tty->termios.c_cflag & PARENB) {
-            if (tty->termios.c_cflag & PARODD)
-                l = epicsSnprintf(val, valSize, "odd");
-            else
-                l = epicsSnprintf(val, valSize, "even");
+            if (tty->termios.c_cflag & CMSPAR) {
+				if (tty->termios.c_cflag & PARODD)
+					l = epicsSnprintf(val, valSize, "mark");
+				else
+					l = epicsSnprintf(val, valSize, "space");
+			else {
+				if (tty->termios.c_cflag & PARODD)
+					l = epicsSnprintf(val, valSize, "odd");
+				else
+					l = epicsSnprintf(val, valSize, "even");
+			}
         }
         else {
             l = epicsSnprintf(val, valSize, "none");
@@ -379,6 +386,16 @@ setOption(void *drvPvt, asynUser *pasynUser, const char *key, const char *val)
         }
         else if (epicsStrCaseCmp(val, "odd") == 0) {
             tty->termios.c_cflag |= PARENB;
+            tty->termios.c_cflag |= PARODD;
+        }
+        else if (epicsStrCaseCmp(val, "space") == 0) {
+            tty->termios.c_cflag |= PARENB;
+            tty->termios.c_cflag |= CMSPAR;
+            tty->termios.c_cflag &= ~PARODD;
+        }
+        else if (epicsStrCaseCmp(val, "mark") == 0) {
+            tty->termios.c_cflag |= PARENB;
+            tty->termios.c_cflag |= CMSPAR;
             tty->termios.c_cflag |= PARODD;
         }
         else {

--- a/asyn/drvAsynSerial/drvAsynSerialPort.h
+++ b/asyn/drvAsynSerial/drvAsynSerialPort.h
@@ -22,6 +22,7 @@ extern "C" {
 /* Define additional pasynUser->auxStatus error masks */
 #define ASYN_ERROR_PARITY  0x0001
 #define ASYN_ERROR_FRAMING 0x0002
+#define CMSPAR 010000000000
 
 epicsShareFunc int drvAsynSerialPortConfigure(char *portName,
                                               char *ttyName,

--- a/asyn/drvAsynSerial/drvAsynSerialPort.h
+++ b/asyn/drvAsynSerial/drvAsynSerialPort.h
@@ -22,7 +22,6 @@ extern "C" {
 /* Define additional pasynUser->auxStatus error masks */
 #define ASYN_ERROR_PARITY  0x0001
 #define ASYN_ERROR_FRAMING 0x0002
-#define CMSPAR 010000000000
 
 epicsShareFunc int drvAsynSerialPortConfigure(char *portName,
                                               char *ttyName,

--- a/asyn/drvAsynSerial/drvAsynSerialPortWin32.c
+++ b/asyn/drvAsynSerial/drvAsynSerialPortWin32.c
@@ -122,6 +122,12 @@ getOption(void *drvPvt, asynUser *pasynUser,
             case 2:
                 l = epicsSnprintf(val, valSize, "even");
                 break;
+			case 3:
+				l = epicsSnprintf(val, valSize, "mark");
+				break;
+			case 4:
+				l = epicsSnprintf(val, valSize, "space");
+				break;
         }
     }
     else if (epicsStrCaseCmp(key, "stop") == 0) {
@@ -211,6 +217,12 @@ setOption(void *drvPvt, asynUser *pasynUser, const char *key, const char *val)
         else if (epicsStrCaseCmp(val, "even") == 0) {
             tty->commConfig.dcb.Parity = 2;
         }
+		else if (epicsStrCaseCmp(val, "mark") == 0) {
+			tty->commConfig.dcb.Parity = 3;
+		}
+		else if (epicsStrCaseCmp(val, "space") == 0) {
+			tty->commConfig.dcb.Parity = 4;
+		}
         else {
             epicsSnprintf(pasynUser->errorMessage,pasynUser->errorMessageSize,
                                                             "Invalid parity.");


### PR DESCRIPTION
There was a need for space parity for one device, it was not much effort to include mark as well.

At present this has been added only to the windows version as Linux does not use Space or Mark parity, and has some interesting work arounds to allow them to be used.

Testing during development was undertaken by using an existing asyn ioc and changing the parity type, then running it. It was verified that the value was being set by connecting to the moxa hosting the COM port being used by the IOC, and checking the async-Settings (Moxa page > Monitor > Async-Setting) were updated as appropriate. Please note that the test required a make of support/asyn, support/ioc and epics/ioc/master.

see ISISComputingGroup/IBEX#2461
