### PR TITLE
Suppresses printing messages that we have not subscribed to

### DIFF
--- a/asyn/drvAsynSerial/drvAsynSerialPortWin32.c
+++ b/asyn/drvAsynSerial/drvAsynSerialPortWin32.c
@@ -224,6 +224,11 @@ static void monitorComEvents(void* arg)
 			}
 		}
 		getTimestamp(datetime, sizeof(datetime));
+
+		/* The following extra logic has been added to hide messages from a USB driver which did not strictly adhere to event masks.
+		   It checks the received masks against those suppied and so ensures that even if the driver sends an unsolicited message, it does not get printed.
+		*/
+
 		if ((evtMask & EV_ERR) && (tty->commEventMask & EV_ERR))
 		{
 			printf("%s: %s COM event: line status error: frame, overrun or parity error\n", datetime, tty->serialDeviceName);

--- a/asyn/drvAsynSerial/drvAsynSerialPortWin32.c
+++ b/asyn/drvAsynSerial/drvAsynSerialPortWin32.c
@@ -224,27 +224,27 @@ static void monitorComEvents(void* arg)
 			}
 		}
 		getTimestamp(datetime, sizeof(datetime));
-		if (evtMask & EV_ERR)
+		if ((evtMask & EV_ERR) && (tty->commEventMask & EV_ERR))
 		{
 			printf("%s: %s COM event: line status error: frame, overrun or parity error\n", datetime, tty->serialDeviceName);
 		}
-		if (evtMask & EV_CTS)
+		if ((evtMask & EV_CTS) && (tty->commEventMask & EV_CTS))
 		{
 			printf("%s: %s COM event: CTS state change\n", datetime, tty->serialDeviceName);
 		}
-		if (evtMask & EV_DSR)
+		if ((evtMask & EV_DSR) && (tty->commEventMask & EV_DSR))
 		{
 			printf("%s: %s COM event: DSR state change\n", datetime, tty->serialDeviceName);
 		}
-		if (evtMask & EV_BREAK)
+		if ((evtMask & EV_BREAK) && (tty->commEventMask & EV_BREAK))
 		{
 			printf("%s: %s COM event: break detected\n", datetime, tty->serialDeviceName);
 		}
-		if (evtMask & EV_RLSD)
+		if ((evtMask & EV_RLSD) && (tty->commEventMask & EV_RLSD))
 		{
 			printf("%s: %s COM event: DCD/RLSD state change\n", datetime, tty->serialDeviceName);
 		}
-		if (evtMask & EV_RING)
+		if ((evtMask & EV_RING) && (tty->commEventMask & EV_RING))
 		{
 			printf("%s: %s COM event: ring indicator detected\n", datetime, tty->serialDeviceName);
 		}
@@ -256,11 +256,11 @@ static void monitorComEvents(void* arg)
 			    printf("%s: %s COM event: character received and placed in input buffer\n", datetime, tty->serialDeviceName);
 			}
 		}
-		if (evtMask & EV_RXFLAG)
+		if ((evtMask & EV_RXFLAG) && (tty->commEventMask & EV_RXFLAG))
 		{
 			printf("%s: %s COM event: event character received\n", datetime, tty->serialDeviceName);
 		}
-		if (evtMask & EV_TXEMPTY)
+		if ((evtMask & EV_TXEMPTY) && (tty->commEventMask & EV_TXEMPTY))
 		{
 			printf("%s: %s COM event: last character sent from output buffer\n", datetime, tty->serialDeviceName);
 		}


### PR DESCRIPTION
For https://github.com/ISISComputingGroup/IBEX/issues/6678

@FreddieAkeroyd fyi as I think you have added various features to this driver previously.

This device uses a USB interface which emulates a COM port. It looks like the USB-serial driver on this device is possibly buggy and sends events even if they do not match the mask that we've specified in `SetCommMask`. This causes asyn to print many messages of the form `last character sent from output buffer` - even though these are not specified in our event mask (we double checked this by explicitly setting a mask too).

This change double checks the event mask against the mask that we provided just before each message gets printed - so even if the underlying driver does not respect the mask we've set, we should not see these messages.

Note: for the avoidance of doubt this device is **not** using moxa nport - it is a usb device emulating its own COM port, and connected via a USBanywhere box.

Pair programmed with @Tom-Willemsen 