### PR TITLE
Avoid sharing asynUser

### DIFF
--- a/asyn/drvAsynSerial/drvAsynSerialPortWin32.c
+++ b/asyn/drvAsynSerial/drvAsynSerialPortWin32.c
@@ -198,9 +198,9 @@ static int waitForBytes(ttyController_t *tty, asynUser* pasynUser, double timeou
 /* monitor and print requested comm events */
 static void monitorComEvents(void* arg)
 {
-    /* if we wanted to asynPrint etc then we probably need to duplicate and asynUser as
-       sharing tty->pasynUser is not recommended. However i was not sure how freeing this duplicate
-       and disconnect() interact, but as we don't need to print really i'll just remove prints asynPrint for now */
+    /* if we wanted to asynPrint() etc then we probably need to duplicateAsynUser() as
+       sharing tty->pasynUser is not recommended. However i was not sure how freeAsynUser with this duplicate
+       and disconnect() interact, but as we don't need to asynPrint explicitly i'll just use printf instead */
 	char datetime[64];
 	ttyController_t *tty = (ttyController_t *)arg;
 	DWORD evtMask, error, readTotal;

--- a/asyn/drvAsynSerial/drvAsynSerialPortWin32.c
+++ b/asyn/drvAsynSerial/drvAsynSerialPortWin32.c
@@ -198,11 +198,13 @@ static int waitForBytes(ttyController_t *tty, asynUser* pasynUser, double timeou
 /* monitor and print requested comm events */
 static void monitorComEvents(void* arg)
 {
+    /* if we wanted to asynPrint etc then we probably need to duplicate and asynUser as
+       sharing tty->pasynUser is not recommended. However i was not sure how freeing this duplicate
+       and disconnect() interact, but as we don't need to print really i'll just remove prints asynPrint for now */
 	char datetime[64];
 	ttyController_t *tty = (ttyController_t *)arg;
 	DWORD evtMask, error, readTotal;
-	asynPrint(tty->pasynUser, ASYN_TRACE_FLOW,
-		"%s started monitorComEvents thread.\n", tty->serialDeviceName);
+	printf("%s started monitorComEvents thread.\n", tty->serialDeviceName);
 	while(1)
 	{
 		if (GetCommMask(tty->commHandle, &evtMask) == 0 || evtMask == 0)
@@ -270,8 +272,7 @@ static void monitorComEvents(void* arg)
 			printf("%s: %s COM event: last character sent from output buffer\n", datetime, tty->serialDeviceName);
 		}
 	}
-	asynPrint(tty->pasynUser, ASYN_TRACE_FLOW,
-		"%s terminated monitorComEvents thread.\n", tty->serialDeviceName);
+	printf("%s terminated monitorComEvents thread.\n", tty->serialDeviceName);
 }
 
 /*


### PR DESCRIPTION
Change `asynPrint` to `printf` so as not to share an asynUser between threads. Fixes occasional race condition crash on instruments when thread first created
```
asyn!getTraceMask(struct asynUser * pasynUser = 0x00000000`00000003) [C:\Instrument\Apps\EPICS\support\asyn\master\asyn\asynDriver\asynManager.c @ 2620] 
asyn!monitorComEvents(void * arg = 0x000001ae`2815ada0)+0x30 [C:\Instrument\Apps\EPICS\support\asyn\master\asyn\drvAsynSerial\drvAsynSerialPortWin32.c @ 204] 
Com!epicsWin32ThreadEntry(void * lpParameter = 0x000001ae`2810d500)+0x4c [C:\Instrument\Apps\EPICS\base\master\modules\libcom\src\osi\os\WIN32\osdThread.c @ 439] 
```
`asynPrint` calls `getTraceMask`. 